### PR TITLE
Make SwiftPlate into a Swift script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,13 @@ Just run `swiftplate`, and you’ll be presented with a simple step-by-step guid
 
 ## Usage
 
-- Open `SwiftPlate.xcodeproj`.
-
 Either:
 
-- Run it from Xcode, and use Xcode’s console to provide input.
+- Run 'main.swift' in your terminal.
 
 or
 
+- Open `SwiftPlate.xcodeproj`.
 - Archive the project.
 - Move the built binary to `/usr/local/bin`.
 - Run `swiftplate` in your terminal.

--- a/main.swift
+++ b/main.swift
@@ -1,3 +1,5 @@
+#!/usr/bin/swift
+
 /**
  *  SwiftPlate
  *


### PR DESCRIPTION
It's possible to vastly simplify usage of SwiftPlate by turning it into an executable Swift script (removing Xcode from the equation altogether). What do you reckon?  