### PR TITLE
Update source files in podspec template

### DIFF
--- a/Template/{PROJECT}.podspec
+++ b/Template/{PROJECT}.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
   s.source       = { :git => "{URL}.git", :tag => "0.1" }
-  s.source_files  = "Sources/{PROJECT}.swift"
+  s.source_files  = "Sources/**/*"
   s.frameworks  = "Foundation"
 end


### PR DESCRIPTION
If you create a new pod through cocoapods all files in `/Classes/**/*` get pulled in as source files. Imho that's a saner default compared to defaulting to the base file only.