### PR TITLE
Wrap document path in quotes

### DIFF
--- a/main.swift
+++ b/main.swift
@@ -172,7 +172,7 @@ func askForDestination() -> String {
 func performGitClone(path: String) throws {
     let process = Process()
     process.launchPath = "/bin/bash"
-    process.arguments = ["-c", "git clone https://github.com/JohnSundell/SwiftPlate.git \(path) -q"]
+    process.arguments = ["-c", "git clone https://github.com/JohnSundell/SwiftPlate.git '\(path)' -q"]
     process.launch()
     process.waitUntilExit()
 }


### PR DESCRIPTION
As the document paths may have spaces, wrap them up in quotes to stop the command line treating them as new arguments. #10 