### PR TITLE
Install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Either:
 
 or
 
+- run `./install.sh` from the root directory which will build the project and copy the build binary to `/usr/local/bin`.
+
+or
+
 - Open `SwiftPlate.xcodeproj`.
 - Run the project, and use Xcode’s console to provide input.
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+xcodebuild
+cp build/Release/swiftplate /usr/local/bin


### PR DESCRIPTION
Add a convenience build script.

This simply runs `xcodebuild` over the project which uses the single scheme and the Release configuration, and then copies the built binary to the recommended location.