### PR TITLE
Added Linux library Unit testing to boilerplate

### DIFF
--- a/Template/Tests/LinuxMain.swift
+++ b/Template/Tests/LinuxMain.swift
@@ -1,0 +1,6 @@
+import XCTest
+@testable import {PROJECT}Tests
+
+XCTMain([
+          testCase({PROJECT}Tests.allTests),
+])

--- a/Template/Tests/LinuxMain.swift
+++ b/Template/Tests/LinuxMain.swift
@@ -2,5 +2,5 @@ import XCTest
 @testable import {PROJECT}Tests
 
 XCTMain([
-          testCase({PROJECT}Tests.allTests),
+    testCase({PROJECT}Tests.allTests),
 ])

--- a/Template/Tests/{PROJECT}Tests/{PROJECT}Tests.swift
+++ b/Template/Tests/{PROJECT}Tests/{PROJECT}Tests.swift
@@ -27,6 +27,12 @@ import XCTest
 import {PROJECT}
 
 class {PROJECT}Tests: XCTestCase {
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        //// XCTAssertEqual({PROJECT}().text, "Hello, World!")
+    }
+
 
 }
 

--- a/Template/Tests/{PROJECT}Tests/{PROJECT}Tests.swift
+++ b/Template/Tests/{PROJECT}Tests/{PROJECT}Tests.swift
@@ -27,5 +27,16 @@ import XCTest
 import {PROJECT}
 
 class {PROJECT}Tests: XCTestCase {
-    
+
 }
+
+#if os(Linux)
+extension {PROJECT}Tests {
+    static var allTests : [(String, ({PROJECT}Tests) -> () throws -> Void)] {
+        // FIXME: Should return a list of test case (name, function) tuples
+        return [
+          ("testExample", testExample),
+        ]
+    }
+}
+#endif

--- a/Template/Tests/{PROJECT}Tests/{PROJECT}Tests.swift
+++ b/Template/Tests/{PROJECT}Tests/{PROJECT}Tests.swift
@@ -39,7 +39,6 @@ class {PROJECT}Tests: XCTestCase {
 #if os(Linux)
 extension {PROJECT}Tests {
     static var allTests : [(String, ({PROJECT}Tests) -> () throws -> Void)] {
-        // FIXME: Should return a list of test case (name, function) tuples
         return [
           ("testExample", testExample),
         ]


### PR DESCRIPTION
 - Did NOT add a question about Linux support.  Instead, added to
   Templates/ code that will still work unchanged under macOS, *OS. This
   is related to other details that I will describe.

 - do not see a conventional way to conditionally include snippets into
   a Template/ output file, so instead I added a conditional extension
   for Linux only. Snippets ability would be useful in many ways:
   include example unit testing code and an example object (struct,
   e.g.) in the Sources/ if, and only if, an optional Boolean such as
   "Linux Unit testing support" was added to user prompt.

 - tested under macOS. running `testStructure.py` passed.

 - compilation under Linux will fail, due to `testExample` not being
   defined (see above about example unit testing code)