### PR TITLE
Fix for python syntax error in testStructure.py

### DIFF
--- a/testStructure.py
+++ b/testStructure.py
@@ -1,3 +1,6 @@
+
+# -*- coding: utf-8 -*-
+
 import sys
 import os
 from os.path import join, getsize


### PR DESCRIPTION
 - since the file has non-ASCII characters, it can fail with a compile
   error if the doc type is not specified. This edit corrects for that.

Platform: macOS 10.12, Python 2.7.12 

### Error example
`$ python ../SwiftPlate/testStructure.py test`

	File "testStructure.py", line 30
	SyntaxError: Non-ASCII character '\xe2' in file testStructure.py on line 30, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details