### PR TITLE
Replaced MIT license header with Xcode header #19

### DIFF
--- a/Template/Sources/{PROJECT}.swift
+++ b/Template/Sources/{PROJECT}.swift
@@ -1,25 +1,9 @@
-/**
- *  {PROJECT}
- *
- *  Copyright (c) {YEAR} {AUTHOR}. Licensed under the MIT license, as follows:
- *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
- *
- *  The above copyright notice and this permission notice shall be included in all
- *  copies or substantial portions of the Software.
- *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- *  SOFTWARE.
- */
+//
+//  {PROJECT}.swift
+//  {ORGANIZATION}
+//
+//  Created by {AUTHOR} on {{TODAY}}.
+//  Copyright © {YEAR} {ORGANIZATION}. All rights reserved.
+//
 
 import Foundation

--- a/Template/Sources/{PROJECT}.swift
+++ b/Template/Sources/{PROJECT}.swift
@@ -2,7 +2,7 @@
 //  {PROJECT}.swift
 //  {ORGANIZATION}
 //
-//  Created by {AUTHOR} on {{TODAY}}.
+//  Created by {AUTHOR} on {TODAY}.
 //  Copyright © {YEAR} {ORGANIZATION}. All rights reserved.
 //
 

--- a/Template/Tests/{PROJECT}Tests/{PROJECT}Tests.swift
+++ b/Template/Tests/{PROJECT}Tests/{PROJECT}Tests.swift
@@ -2,7 +2,7 @@
 //  {PROJECT}Tests.swift
 //  {ORGANIZATION}
 //
-//  Created by {AUTHOR} on {{TODAY}}.
+//  Created by {AUTHOR} on {TODAY}.
 //  Copyright © {YEAR} {ORGANIZATION}. All rights reserved.
 //
 

--- a/Template/Tests/{PROJECT}Tests/{PROJECT}Tests.swift
+++ b/Template/Tests/{PROJECT}Tests/{PROJECT}Tests.swift
@@ -1,26 +1,10 @@
-/**
- *  {PROJECT}
- *
- *  Copyright (c) {YEAR} {AUTHOR}. Licensed under the MIT license, as follows:
- *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
- *
- *  The above copyright notice and this permission notice shall be included in all
- *  copies or substantial portions of the Software.
- *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- *  SOFTWARE.
- */
+//
+//  {PROJECT}Tests.swift
+//  {ORGANIZATION}
+//
+//  Created by {AUTHOR} on {{TODAY}}.
+//  Copyright © {YEAR} {ORGANIZATION}. All rights reserved.
+//
 
 import Foundation
 import XCTest

--- a/main.swift
+++ b/main.swift
@@ -65,6 +65,7 @@ class StringReplacer {
     private let authorEmail: String
     private let gitHubURL: String
     private let year: String
+    private let today: String
     private let organizationName: String
 
     init(projectName: String, authorName: String, authorEmail: String?, gitHubURL: String?, organizationName: String?) {
@@ -77,6 +78,11 @@ class StringReplacer {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "YYYY"
         self.year = dateFormatter.string(from: Date())
+        self.today = DateFormatter.localizedString(
+            from: Date(),
+            dateStyle: DateFormatter.Style.medium,
+            timeStyle: DateFormatter.Style.none
+        )
     }
     
     func process(string: String) -> String {
@@ -85,6 +91,7 @@ class StringReplacer {
                      .replacingOccurrences(of: "{EMAIL}", with: authorEmail)
                      .replacingOccurrences(of: "{URL}", with: gitHubURL)
                      .replacingOccurrences(of: "{YEAR}", with: year)
+                     .replacingOccurrences(of: "{TODAY}", with: today)
                      .replacingOccurrences(of: "{ORGANIZATION}", with: organizationName)
     }
     

--- a/main.swift
+++ b/main.swift
@@ -138,7 +138,6 @@ class StringReplacer {
     private let authorEmail: String
     private let gitHubURL: String
     private let year: String
-    private let today: String
     private let organizationName: String
     
     init(projectName: String, authorName: String, authorEmail: String?, gitHubURL: String?, organizationName: String?) {
@@ -151,7 +150,10 @@ class StringReplacer {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "YYYY"
         self.year = dateFormatter.string(from: Date())
-        self.today = DateFormatter.localizedString(
+    }
+    
+    private var dateString: String {
+        return DateFormatter.localizedString(
             from: Date(),
             dateStyle: DateFormatter.Style.medium,
             timeStyle: DateFormatter.Style.none
@@ -164,7 +166,7 @@ class StringReplacer {
                      .replacingOccurrences(of: "{EMAIL}", with: authorEmail)
                      .replacingOccurrences(of: "{URL}", with: gitHubURL)
                      .replacingOccurrences(of: "{YEAR}", with: year)
-                     .replacingOccurrences(of: "{TODAY}", with: today)
+                     .replacingOccurrences(of: "{DATE}", with: dateString)
                      .replacingOccurrences(of: "{ORGANIZATION}", with: organizationName)
     }
     


### PR DESCRIPTION
This PR replaces the MIT headers in `{PROJECT}.swift` and `{PROJECT}Tests.swift` with headers Xcode would generate.

But I am not sure how to handle different licenses.