### PR TITLE
Ignore copying README & LICENSE files if they already exist

### DIFF
--- a/main.swift
+++ b/main.swift
@@ -361,9 +361,18 @@ do {
     }
     
     try performCommand(description: "Copying template folder") {
+        let ignorableItems = ["README.md", "LICENSE"]
+
         for itemName in try fileManager.contentsOfDirectory(atPath: templatePath) {
             let originPath = templatePath + "/" + itemName
             let destinationPath = destination + "/" + itemName
+
+            if ignorableItems.contains(itemName) {
+                guard fileManager.fileExists(atPath: destinationPath) == false else {
+                    continue
+                }
+            }
+
             try fileManager.copyItem(atPath: originPath, toPath: destinationPath)
         }
     }

--- a/main.swift
+++ b/main.swift
@@ -361,16 +361,20 @@ do {
     }
     
     try performCommand(description: "Copying template folder") {
-        let ignorableItems = ["README.md", "LICENSE"]
+        let ignorableItems = ["readme.md", "license"]
+        let ignoredItems = try fileManager.contentsOfDirectory(atPath: destination).map {
+            $0.lowercased()
+        }.filter {
+            ignorableItems.contains($0)
+        }
 
         for itemName in try fileManager.contentsOfDirectory(atPath: templatePath) {
             let originPath = templatePath + "/" + itemName
             let destinationPath = destination + "/" + itemName
 
-            if ignorableItems.contains(itemName) {
-                guard fileManager.fileExists(atPath: destinationPath) == false else {
-                    continue
-                }
+            let lowercasedItemName = itemName.lowercased()
+            guard ignoredItems.contains(lowercasedItemName) == false else {
+                continue
             }
 
             try fileManager.copyItem(atPath: originPath, toPath: destinationPath)

--- a/main.swift
+++ b/main.swift
@@ -361,7 +361,7 @@ do {
     }
     
     try performCommand(description: "Copying template folder") {
-        let ignorableItems = ["readme.md", "license"]
+        let ignorableItems: Set<String> = ["readme.md", "license"]
         let ignoredItems = try fileManager.contentsOfDirectory(atPath: destination).map {
             $0.lowercased()
         }.filter {


### PR DESCRIPTION
If a README.md and/or a LICENSE files already exist in the destination directory, SwiftPlate will no longer attempt to overwrite them.

This fixes #36.