### PR TITLE
Adding check to prevent the source file from being overwritten by itself

### DIFF
--- a/main.swift
+++ b/main.swift
@@ -165,10 +165,12 @@ class StringReplacer {
         let fileManager = FileManager.default
         
         for itemName in try fileManager.contentsOfDirectory(atPath: folderPath) {
-            if itemName.hasPrefix(".") {
+            let currentFileName = URL.init(fileURLWithPath: #file).lastPathComponent
+
+            if itemName.hasPrefix(".") || itemName == currentFileName {
                 continue
             }
-            
+
             let itemPath = folderPath + "/" + itemName
             let newItemPath = folderPath + "/" + process(string: itemName)
             

--- a/main.swift
+++ b/main.swift
@@ -163,10 +163,9 @@ class StringReplacer {
     
     func process(filesInFolderWithPath folderPath: String) throws {
         let fileManager = FileManager.default
-        
-        for itemName in try fileManager.contentsOfDirectory(atPath: folderPath) {
-            let currentFileName = URL.init(fileURLWithPath: #file).lastPathComponent
+        let currentFileName = URL.init(fileURLWithPath: #file).lastPathComponent
 
+        for itemName in try fileManager.contentsOfDirectory(atPath: folderPath) {
             if itemName.hasPrefix(".") || itemName == currentFileName {
                 continue
             }


### PR DESCRIPTION
Fix for #39 
Scenario: When the `main.swift` file is in the same folder as the target folder and we perform consecutive runs.

Effect: Looks like the `main.swift` was getting internally overwritten when the script was executed for the first time. Thereby corrupting the file for consecutive runs.

Fix: A check to prevent modifications to the source file which is executing the script.