### PR TITLE
Simplify `allTests` property in Tests

### DIFF
--- a/Template/Tests/{PROJECT}Tests/{PROJECT}Tests.swift
+++ b/Template/Tests/{PROJECT}Tests/{PROJECT}Tests.swift
@@ -16,14 +16,8 @@ class {PROJECT}Tests: XCTestCase {
         // Use XCTAssert and related functions to verify your tests produce the correct results.
         //// XCTAssertEqual({PROJECT}().text, "Hello, World!")
     }
+    
+    static var allTests = [
+        ("testExample", testExample),
+    ]
 }
-
-#if os(Linux)
-extension {PROJECT}Tests {
-    static var allTests : [(String, ({PROJECT}Tests) -> () throws -> Void)] {
-        return [
-            ("testExample", testExample),
-        ]
-    }
-}
-#endif


### PR DESCRIPTION
The change is what SPM currently generates for a new project using `$ swift package init`. Removing the guard for `os(Linux)` has the added benefit of the compiler checking this on macOS as well. And removing the type signature just makes it look a lot cleaner 😊 