### PR TITLE
Travis via fastlane

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ SwiftPlate will generate Xcode projects for you in seconds, that support:
 - [x] watchOS
 - [x] tvOS
 - [x] Linux
+- [x] Travis CI (via Fastlane - Mac environment only)
 
 Just run `swiftplate`, and you’ll be presented with a simple step-by-step guide:
 

--- a/Template/.gitignore
+++ b/Template/.gitignore
@@ -65,3 +65,4 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+fastlane/README.md

--- a/Template/.travis.yml
+++ b/Template/.travis.yml
@@ -1,0 +1,6 @@
+language: objective-c
+osx_image: xcode8.3
+before_install:
+- gem update fastlane
+script:
+- fastlane test

--- a/Template/fastlane/Fastfile
+++ b/Template/fastlane/Fastfile
@@ -1,0 +1,69 @@
+# Customise this file, documentation can be found here:
+# https://github.com/fastlane/fastlane/tree/master/fastlane/docs
+# All available actions: https://docs.fastlane.tools/actions
+# can also be listed using the `fastlane actions` command
+
+# Change the syntax highlighting to Ruby
+# All lines starting with a # are ignored when running `fastlane`
+
+# If you want to automatically update fastlane if a new version is available:
+# update_fastlane
+
+# This is the minimum version number required.
+# Update this, if you use features of a newer version
+fastlane_version "2.16.0"
+
+default_platform :ios
+
+platform :ios do
+
+	desc "Builds the framework and runs all the tests"
+	lane :test do
+
+		# Prevent timeout issues
+		ENV["FASTLANE_XCODE_LIST_TIMEOUT"] = "120" 
+
+		# Just build the watchOS target (no tests)
+		xcodebuild(
+			project: "{PROJECT}.xcodeproj",
+		    scheme: "{PROJECT}-watchOS",
+		    clean: true,
+		    build: true
+	  	)
+
+		# Build and test the macOS target
+		scan(
+			project: "{PROJECT}.xcodeproj",
+			scheme: "{PROJECT}-macOS",
+			devices: [
+				# (deliberately empty, will use the mac this is running on)
+			],
+			clean: true,
+			skip_slack: true
+		)
+
+		# Build and test the iOS target
+		scan(
+			project: "{PROJECT}.xcodeproj",
+			scheme: "{PROJECT}-iOS",
+			devices: [
+				"iPhone SE",
+				# "iPhone 6",
+				# "iPhone 7 Plus",
+			],
+			clean: true,
+			skip_slack: true
+		)
+
+		# Build and test the tvOS target
+		scan(
+			project: "{PROJECT}.xcodeproj",
+			scheme: "{PROJECT}-tvOS",
+			devices: [
+				"Apple TV 1080p",
+			],
+			clean: true,
+			skip_slack: true
+		)
+	end
+end


### PR DESCRIPTION
Hi John, I think this project is great and I'm looking at things that would take even more steps away from the average developer's initial workflow.

This is a TravisCI + Fastlane combo, which in my experience it works a treat for simplifying the commands needed to build and test (without even getting into all the other delivery related goodies that are on offer). As you can see in the travis config, the advantage of using Fastlane for this purpose is that the entry point is dead simple and should make it easy to add other CI services as well.

Specifically the Fastlane script exercises all 3 test targets and also builds the watch one. If someone wants to remove a target because they're not supporting it they just delete the relevant `scan` step. Any more iOS devices can be easily added and I've left some examples commented out.

Lemme know what you think!