### PR TITLE
Fixes the year date formatter

### DIFF
--- a/main.swift
+++ b/main.swift
@@ -150,7 +150,7 @@ class StringReplacer {
         
 
         let yearFormatter = DateFormatter()
-        yearFormatter.dateFormat = "YYYY"
+        yearFormatter.dateFormat = "yyyy"
         self.year = yearFormatter.string(from: Date())
 
         let dateFormatter = DateFormatter()


### PR DESCRIPTION
I made a new project today and my `LICENSE` file was generated with the year of 2019 instead of 2018. After confirming that I had not lost track of a few days of my life, I dug through the code and found a small bug in the date formatter. It was using `YYYY` instead of `yyyy`. Here's a thread on stack overflow with some more information: https://stackoverflow.com/questions/15133549/difference-between-yyyy-and-yyyy-in-nsdateformatter